### PR TITLE
Changed the level bonuses for Aether Lens and Dragon Javelins

### DIFF
--- a/scripts/npc/npc_items_custom.txt
+++ b/scripts/npc/npc_items_custom.txt
@@ -119,7 +119,7 @@
 			"01"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"bonus_mana"			"250"
+				"bonus_mana"			"300"
 			}
 			"02"
 			{
@@ -165,12 +165,12 @@
             "01"
             {
                 "var_type"				"FIELD_INTEGER"
-                "bonus_mana"			"250"
+                "bonus_mana"			"350"
             }
             "02"
             {
                 "var_type"				"FIELD_INTEGER"
-                "bonus_health_regen"	"9"
+                "bonus_health_regen"	"10"
             }
             "03"
             {
@@ -211,12 +211,12 @@
             "01"
             {
                 "var_type"				"FIELD_INTEGER"
-                "bonus_mana"			"250"
+                "bonus_mana"			"400"
             }
             "02"
             {
                 "var_type"				"FIELD_INTEGER"
-                "bonus_health_regen"	"9"
+                "bonus_health_regen"	"11"
             }
             "03"
             {
@@ -257,12 +257,12 @@
             "01"
             {
                 "var_type"				"FIELD_INTEGER"
-                "bonus_mana"			"250"
+                "bonus_mana"			"450"
             }
             "02"
             {
                 "var_type"				"FIELD_INTEGER"
-                "bonus_health_regen"	"9"
+                "bonus_health_regen"	"12"
             }
             "03"
             {
@@ -1360,7 +1360,7 @@
             "02"
             {
                 "var_type"				"FIELD_INTEGER"
-                "bonus_agility"			"15"
+                "bonus_agility"			"17"
             }
             "03"
             {
@@ -1529,17 +1529,17 @@
             "01"
             {
                 "var_type"				"FIELD_INTEGER"
-                "bonus_damage"			"10"
+                "bonus_damage"			"15"
             }
             "02"
             {
                 "var_type"				"FIELD_INTEGER"
-                "bonus_agility"			"15"
+                "bonus_agility"			"20"
             }
             "03"
             {
                 "var_type"				"FIELD_INTEGER"
-                "bonus_strength"		"15"
+                "bonus_strength"		"17"
             }
             "04"
             {
@@ -1685,17 +1685,17 @@
              "01"
              {
                  "var_type"				"FIELD_INTEGER"
-                 "bonus_damage"			"10"
+                 "bonus_damage"			"20"
              }
              "02"
              {
                  "var_type"				"FIELD_INTEGER"
-                 "bonus_agility"			"15"
+                 "bonus_agility"			"23"
              }
              "03"
              {
                  "var_type"				"FIELD_INTEGER"
-                 "bonus_strength"		"15"
+                 "bonus_strength"		"19"
              }
              "04"
              {
@@ -1841,17 +1841,17 @@
              "01"
              {
                  "var_type"				"FIELD_INTEGER"
-                 "bonus_damage"			"10"
+                 "bonus_damage"			"25"
              }
              "02"
              {
                  "var_type"				"FIELD_INTEGER"
-                 "bonus_agility"			"15"
+                 "bonus_agility"			"26"
              }
              "03"
              {
                  "var_type"				"FIELD_INTEGER"
-                 "bonus_strength"		"15"
+                 "bonus_strength"		"21"
              }
              "04"
              {
@@ -1997,17 +1997,17 @@
               "01"
               {
                   "var_type"				"FIELD_INTEGER"
-                  "bonus_damage"			"10"
+                  "bonus_damage"			"30"
               }
               "02"
               {
                   "var_type"				"FIELD_INTEGER"
-                  "bonus_agility"			"15"
+                  "bonus_agility"			"29"
               }
               "03"
               {
                   "var_type"				"FIELD_INTEGER"
-                  "bonus_strength"		"15"
+                  "bonus_strength"		"23"
               }
               "04"
               {


### PR DESCRIPTION
- Bonus stats for Aether lens(+50 mana pool and +1 hp regen per level, +old bonuses)
- Bonus stats for Dragon Javelins(+5 damage, +3 agility, +2 strength per level, +old bonuses)