### PR TITLE
Difficulty adjustments + hero fixes

### DIFF
--- a/scripts/npc/npc_abilities_custom.txt
+++ b/scripts/npc/npc_abilities_custom.txt
@@ -7628,12 +7628,12 @@
             "01"
             {
                 "var_type"					"FIELD_INTEGER"
-                "damage_increase_pct"		"10 20 30"
+                "damage_increase_pct"		"6 12 18"
             }
             "02"
             {
                 "var_type"					"FIELD_INTEGER"
-                "damage_decrease_pct"		"-10 -20 -30"
+                "damage_decrease_pct"		"-6 -12 -18"
             }
             "03"
             {
@@ -7643,12 +7643,12 @@
             "04"
             {
                 "var_type"					"FIELD_INTEGER"
-                "bonus_armor_building"		"3 6 9"
+                "bonus_armor_building"		"2 4 6"
             }
             "05"
             {
                 "var_type"					"FIELD_INTEGER"
-                "bonus_resist_building"		"5 10 15"
+                "bonus_resist_building"		"4 8 12"
             }
             "06"
             {
@@ -7658,12 +7658,12 @@
             "07"
             {
                 "var_type"					"FIELD_INTEGER"
-                "bonus_resist_creep"		"5 10 15"
+                "bonus_resist_creep"		"4 8 12"
             }
             "08"
             {
                 "var_type"					"FIELD_INTEGER"
-                "bonus_attack_speed_creep"	"5 10 15"
+                "bonus_attack_speed_creep"	"6 12 18"
             }
             "09"
             {
@@ -14871,6 +14871,7 @@
             {
                 "var_type"						"FIELD_INTEGER"
                 "leech_damage"					"15 30 45 60"
+                "LinkedSpecialBonus"			"special_bonus_unique_treant_2"
             }
             "03"
             {

--- a/scripts/npc/npc_abilities_override.txt
+++ b/scripts/npc/npc_abilities_override.txt
@@ -5287,6 +5287,11 @@
     {
         "AbilitySpecial"
         {
+        	"04"
+        	{
+        		"var_type"						"FIELD_FLOAT"
+                "placeholder"					"30 35 40 45"
+        	}
             "05"
             {
                 "var_type"						"FIELD_FLOAT"

--- a/scripts/npc/npc_heroes_custom.txt
+++ b/scripts/npc/npc_heroes_custom.txt
@@ -170,6 +170,7 @@
 	{
 		"override_hero"			"npc_dota_hero_legion_commander"
 		"Ability6"					"legion_commander_duel_datadriven"
+        "Ability13"             "special_bonus_armor_8"
 	}
 	//=================================================================================================================
 	// HERO: Lina
@@ -436,6 +437,14 @@
 		"Ability15"		"special_bonus_cooldown_reduction_20"
 		"Ability16"		"special_bonus_hp_regen_25"
 	}
+    //=================================================================================================================
+    // HERO: Timbersaw
+    //=================================================================================================================
+    "npc_dota_hero_shredder_holdout"
+    {
+        "override_hero"         "npc_dota_hero_shredder"
+        "Ability16"             "special_bonus_movement_speed_90"
+    }
 	//=================================================================================================================
 	// HERO: Tinker
 	//=================================================================================================================
@@ -458,6 +467,15 @@
         "Ability6"				"treant_great_protector"
         // TODO check talent
 	}
+    //=================================================================================================================
+    // HERO: Underlord
+    //=================================================================================================================
+    "npc_dota_hero_abyssal_underlord_holdout"
+    {
+        "override_hero"         "npc_dota_hero_abyssal_underlord"
+        "Ability13"             "special_bonus_unique_underlord_4"
+        "Ability17"             "special_bonus_armor_20"
+    }
 	//=================================================================================================================
 	// HERO: Undying
 	//=================================================================================================================
@@ -492,6 +510,7 @@
 	
 		"Ability4"					"holdout_scourge_ward"					// Ability 3
 		"Ability6"					"venomancer_poison_nova"					// Ability 4
+        "Ability15"                 "special_bonus_attack_damage_60"
 	}
 	//=================================================================================================================
 	// HERO: Viper
@@ -501,8 +520,8 @@
 		"override_hero"			"npc_dota_hero_viper"
 		"Ability1"				"viper_poison_attack_datadriven"
 		"Ability6"              "viper_strike_lua"
-		"Ability14"		"special_bonus_lifesteal_20"
-        "Ability15"		"special_bonus_attack_damage_75"
+		"Ability14"		        "special_bonus_lifesteal_20"
+        "Ability15"		        "special_bonus_mp_regen_6"
 	}
 	//=================================================================================================================
     // HERO: Visage

--- a/scripts/vscripts/heroes/hero_treant/modifier_treant_leech_seed_nb2017.lua
+++ b/scripts/vscripts/heroes/hero_treant/modifier_treant_leech_seed_nb2017.lua
@@ -54,7 +54,8 @@ function modifier_treant_leech_seed_nb2017:OnAttackLanded( params )
 			return 0
 		end
 
-		hAbility:StartCooldown( hAbility:GetCooldown( hAbility:GetLevel() ) )
+		--hAbility:StartCooldown( hAbility:GetCooldown( hAbility:GetLevel() ) )
+		hAbility:UseResources(false,false,true)
 		hTarget:AddNewModifier( self:GetCaster(), self:GetAbility(), "modifier_treant_leech_seed", { duration = self:GetAbility():GetSpecialValueFor( "duration" ) } )
 
 		EmitSoundOn( "Hero_Treant.LeechSeed.Cast", self:GetCaster() )

--- a/scripts/vscripts/libraries/spawners.lua
+++ b/scripts/vscripts/libraries/spawners.lua
@@ -90,7 +90,7 @@ function Spawner:Spawn(keys)
       if difficulty > 0 then
 
         if unit:IsConsideredHero() then
-          unit:SetBaseMaxHealth(unit:GetBaseMaxHealth() * (1 + 0.2 * difficulty))
+          unit:SetBaseMaxHealth(unit:GetBaseMaxHealth() * (1 + 0.1* difficulty))
 
           if difficulty > 1 then
             unit:AddAbility("roshan_spell_block")

--- a/scripts/vscripts/spawners.lua
+++ b/scripts/vscripts/spawners.lua
@@ -194,20 +194,20 @@ function Spawners:LoadMisc(difficulty, mapInfo)
 		end
 	})
     
-	if difficulty < 2 then
+	--if difficulty < 2 then
 		-- spawn money units
-		Spawner:SpawnTimer({
-			start = 0,
-			interval = 3000,
-			spawn = {
-				source =  "spawner10",
-				waypoint = "spawner10",
-				max = 1,
-				order = DOTA_UNIT_ORDER_ATTACK_MOVE,
-				unit = "npc_dota_creature_map_boss"
-			}
-		})
-	end
+	Spawner:SpawnTimer({
+		start = 0,
+		interval = 3000,
+		spawn = {
+			source =  "spawner10",
+			waypoint = "spawner10",
+			max = 1,
+			order = DOTA_UNIT_ORDER_ATTACK_MOVE,
+			unit = "npc_dota_creature_map_boss"
+		}
+	})
+	--end
 
 	-- spawn money units
 	Spawner:SpawnTimer({


### PR DESCRIPTION
// Difficulty
+ Reduced enemy bonuses granted by the difficulty buff
+ Reduced difficulty-based enemy HP multiplier
+ Rapier Ogre now spawns on all difficulties

// Legion Commander
+ Level 15 Overwhelming Odds talent replaced with +8 Armor

// Timbersaw
+ Level 25 Whirling Death talent replaced with +90 Movement Speed

// Treant
+ Leech Seed talent fixed
+ Leech Seed cooldown reduction interaction fixed

// Underlord
+ Atrophy Aura hero reference hidden
+ Level 15 Atrophy Aura talent replaced with Level 25 Firestorm talent
+ Level 25 Firestorm talent replaced with +20 Armor

// Venomancer
+ Level 20 Gale talent replaced with +60 Damage

// Viper
+ Level 20 Damage talent replaced with +6 Mana Regen
